### PR TITLE
feat: Correspondence item permissions

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -555,6 +555,31 @@
       ]
     },
     {
+      "permissionName": "oa.correspondence.item.delete",
+      "displayName": "Correspondence item delete",
+      "description": "Delete a correspondence record"
+    },
+    {
+      "permissionName": "oa.correspondence.item.post",
+      "displayName": "Correspondence item post",
+      "description": "Post a correspondence record"
+    },
+    {
+      "permissionName": "oa.correspondence.item.put",
+      "displayName": "Correspondence item put",
+      "description": "Put a correspondence record"
+    },
+    {
+      "permissionName": "oa.correspondence.item.get",
+      "displayName": "Correspondence item get",
+      "description": "Get a correspondence record"
+    },
+    {
+      "permissionName": "oa.correspondence.collection.get",
+      "displayName": "Correspondence collection get",
+      "description": "Get a collection of correspondence records"
+    },
+    {
       "permissionName": "oa.charges.manage",
       "subPermissions": [
         "oa.charges.edit",


### PR DESCRIPTION
Added permission names, display names and descriptions for all missing correspondence permissions