### PR TITLE
feat: Faculty/department migration

### DIFF
--- a/service/grails-app/domain/org/olf/oa/Party.groovy
+++ b/service/grails-app/domain/org/olf/oa/Party.groovy
@@ -26,13 +26,13 @@ class Party implements MultiTenant<Party> {
     
   String mobile
 
-  String department
+  String institutionLevel2
 
   PartyAddress streetAddress
 
   @CategoryId(defaultInternal=false)
   @Defaults(['Faculty 1'])
-  RefdataValue faculty
+  RefdataValue institutionLevel1
 
   static hasMany = [
     requestParty: RequestParty,
@@ -56,8 +56,8 @@ class Party implements MultiTenant<Party> {
                 mobile column: 'p_mobile'
        alternateEmails cascade: 'all-delete-orphan'
          streetAddress column: 'p_street_address_fk'
-               faculty column: 'p_faculty_fk'
-            department column: 'p_department'
+     institutionLevel1 column: 'p_institution_level_1_fk'
+     institutionLevel2 column: 'p_institution_level_2'
   }
   
   static constraints = {
@@ -70,8 +70,8 @@ class Party implements MultiTenant<Party> {
             phone nullable: true
            mobile nullable: true
     streetAddress nullable: true
-          faculty nullable: true
-       department nullable: true
+institutionLevel1 nullable: true
+institutionLevel2 nullable: true
   }
 
   def beforeValidate() {

--- a/service/grails-app/domain/org/olf/oa/PublicationRequest.groovy
+++ b/service/grails-app/domain/org/olf/oa/PublicationRequest.groovy
@@ -38,7 +38,7 @@ class PublicationRequest extends Workflow implements MultiTenant<PublicationRequ
 
   String bookDateOfPublication
   String bookPlaceOfPublication
-  String correspondingDepartment
+  String correspondingInstitutionLevel2
 
   boolean withoutAgreement = false
 
@@ -76,9 +76,9 @@ class PublicationRequest extends Workflow implements MultiTenant<PublicationRequ
   @Defaults(['Gold', 'Hybrid'])
   RefdataValue workOAStatus
 
-  @CategoryId(value='Party.Faculty', defaultInternal=false)
+  @CategoryId(value='Party.InstitutionLevelOne', defaultInternal=false)
   @Defaults(['Faculty 1'])
-  RefdataValue correspondingFaculty
+  RefdataValue correspondingInstitutionLevel1
 
   static hasMany = [
     externalRequestIds: ExternalRequestId,
@@ -107,71 +107,71 @@ class PublicationRequest extends Workflow implements MultiTenant<PublicationRequ
 
   static mapping = {
     version             false
-    
-    
-                        id column: 'pr_id', generator: 'uuid2', length: 36
-               requestDate column: 'pr_request_date'
-             requestStatus column: 'pr_request_status'
-             requestNumber column: 'pr_request_number'
-               lastUpdated column: 'pr_last_updated'
-               dateCreated column: 'pr_date_created'
-           rejectionReason column: 'pr_rejection_reason'
-          publicationTitle column: 'pr_title'
-           publicationType column: 'pr_pub_type_fk'
-                   subtype column: 'pr_subtype'
-                 publisher column: 'pr_publisher'
-                   license column: 'pr_license'
-            publicationUrl column: 'pr_pub_url'
-            localReference column: 'pr_local_ref'
-               authorNames column: 'pr_authnames'
-                       doi column: 'pr_doi'
-       correspondingAuthor column: 'pr_corresponding_author_fk'
-            requestContact column: 'pr_request_contact_fk'
-          withoutAgreement column: 'pr_without_agreement'
-                      work column: 'pr_work_fk'
-     bookDateOfPublication column: 'pr_book_date_of_publication'
-    bookPlaceOfPublication column: 'pr_book_place_of_publication'
-         workIndexedInDOAJ column: 'pr_work_indexed_in_doaj_fk'
-              workOAStatus column: 'pr_work_oa_status_fk'
-   correspondingDepartment column: 'pr_corresponding_department'
-      correspondingFaculty column: 'pr_corresponding_faculty_fk'
 
-       publicationStatuses cascade: 'all-delete-orphan'
-                  fundings cascade: 'all-delete-orphan'
-        externalRequestIds cascade: 'all-delete-orphan'
-                   history cascade: 'all-delete-orphan'
-               identifiers cascade: 'all-delete-orphan'
-                 agreement cascade: 'all-delete-orphan'
-                   charges cascade: 'all-delete-orphan'
+
+                              id column: 'pr_id', generator: 'uuid2', length: 36
+                     requestDate column: 'pr_request_date'
+                   requestStatus column: 'pr_request_status'
+                   requestNumber column: 'pr_request_number'
+                     lastUpdated column: 'pr_last_updated'
+                     dateCreated column: 'pr_date_created'
+                 rejectionReason column: 'pr_rejection_reason'
+                publicationTitle column: 'pr_title'
+                 publicationType column: 'pr_pub_type_fk'
+                         subtype column: 'pr_subtype'
+                       publisher column: 'pr_publisher'
+                         license column: 'pr_license'
+                  publicationUrl column: 'pr_pub_url'
+                  localReference column: 'pr_local_ref'
+                     authorNames column: 'pr_authnames'
+                             doi column: 'pr_doi'
+             correspondingAuthor column: 'pr_corresponding_author_fk'
+                  requestContact column: 'pr_request_contact_fk'
+                withoutAgreement column: 'pr_without_agreement'
+                            work column: 'pr_work_fk'
+           bookDateOfPublication column: 'pr_book_date_of_publication'
+          bookPlaceOfPublication column: 'pr_book_place_of_publication'
+               workIndexedInDOAJ column: 'pr_work_indexed_in_doaj_fk'
+                    workOAStatus column: 'pr_work_oa_status_fk'
+  correspondingInstitutionLevel1 column: 'pr_corresponding_institution_level_1_fk'
+  correspondingInstitutionLevel2 column: 'pr_corresponding_institution_level_2'
+
+            publicationStatuses cascade: 'all-delete-orphan'
+                       fundings cascade: 'all-delete-orphan'
+             externalRequestIds cascade: 'all-delete-orphan'
+                        history cascade: 'all-delete-orphan'
+                    identifiers cascade: 'all-delete-orphan'
+                      agreement cascade: 'all-delete-orphan'
+                        charges cascade: 'all-delete-orphan'
   }
   
   static constraints = {
-              requestDate nullable: true
-            requestStatus nullable: true
-            requestNumber nullable: true
-              lastUpdated nullable: true
-              dateCreated nullable: true
-          rejectionReason nullable: true
-         publicationTitle nullable: true
-          publicationType nullable: true
-                  subtype nullable: true
-                publisher nullable: true
-                  license nullable: true
-           publicationUrl nullable: true
-           localReference nullable: true
-              authorNames nullable: true
-                      doi nullable: true
-      correspondingAuthor nullable: true
-           requestContact nullable: true
-                agreement nullable: true
-         withoutAgreement(nullable:false, blank:false)
-    bookDateOfPublication(nullable:true, blank:false, matches: '^\\d{4}(-((0[0-9])|(1[0-2]))(-(([0-2][0-9])|3[0-1]))?)?\$')
-   bookPlaceOfPublication(nullable: true)
-                     work nullable: true
-        workIndexedInDOAJ(nullable:true)
-             workOAStatus(nullable:true)
-  correspondingDepartment(nullable:true)
-     correspondingFaculty(nullable:true)
+                   requestDate nullable: true
+                 requestStatus nullable: true
+                 requestNumber nullable: true
+                   lastUpdated nullable: true
+                   dateCreated nullable: true
+               rejectionReason nullable: true
+              publicationTitle nullable: true
+               publicationType nullable: true
+                       subtype nullable: true
+                     publisher nullable: true
+                       license nullable: true
+                publicationUrl nullable: true
+                localReference nullable: true
+                   authorNames nullable: true
+                           doi nullable: true
+           correspondingAuthor nullable: true
+                requestContact nullable: true
+                     agreement nullable: true
+              withoutAgreement(nullable: false, blank:false)
+         bookDateOfPublication(nullable: true, blank:false, matches: '^\\d{4}(-((0[0-9])|(1[0-2]))(-(([0-2][0-9])|3[0-1]))?)?\$')
+        bookPlaceOfPublication(nullable: true)
+                          work nullable: true
+             workIndexedInDOAJ(nullable:true)
+                  workOAStatus(nullable:true)
+correspondingInstitutionLevel1(nullable:true)
+correspondingInstitutionLevel2(nullable:true)
   }
 
   def beforeValidate() {

--- a/service/grails-app/domain/org/olf/oa/PublicationRequest.groovy
+++ b/service/grails-app/domain/org/olf/oa/PublicationRequest.groovy
@@ -76,7 +76,7 @@ class PublicationRequest extends Workflow implements MultiTenant<PublicationRequ
   @Defaults(['Gold', 'Hybrid'])
   RefdataValue workOAStatus
 
-  @CategoryId(value='Party.InstitutionLevelOne', defaultInternal=false)
+  @CategoryId(value='Party.InstitutionLevel1', defaultInternal=false)
   @Defaults(['Faculty 1'])
   RefdataValue correspondingInstitutionLevel1
 

--- a/service/grails-app/migrations/create-mod-oa.groovy
+++ b/service/grails-app/migrations/create-mod-oa.groovy
@@ -1200,7 +1200,7 @@ databaseChangeLog = {
     }
   }
 
-  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1333-02"){
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-28-1333-02"){
     grailsChange{
       change{
         sql.rows("SELECT pr_id, pr_corresponding_faculty_fk, pr_corresponding_department FROM ${database.defaultSchemaName}.publication_request".toString()).each {
@@ -1211,13 +1211,13 @@ databaseChangeLog = {
     }
   }
 
-  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1344-003") {
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-28-1344-003") {
     dropForeignKeyConstraint(baseTableName: "party", constraintName: "party_faculty_fk")
     dropColumn(columnName: "p_faculty_fk", tableName: "party")
     dropColumn(columnName: "p_department", tableName: "party")
   }
 
-  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1344-004") {
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-28-1344-004") {
     dropForeignKeyConstraint(baseTableName: "publication_request", constraintName: "publication_request_corresponding_faculty_fk")
     dropColumn(columnName: "pr_corresponding_faculty_fk", tableName: "publication_request")
     dropColumn(columnName: "pr_corresponding_department", tableName: "publication_request")

--- a/service/grails-app/migrations/create-mod-oa.groovy
+++ b/service/grails-app/migrations/create-mod-oa.groovy
@@ -1150,4 +1150,54 @@ databaseChangeLog = {
       column(name: "ch_payment_period", type: "VARCHAR(36)")
     }
   }
+
+  changeSet(author: "Jack-Golding (manual)", id:"2022-09-27-1137-001"){
+    addColumn (tableName: "publication_request") {
+      column(name: "pr_corresponding_institution_level_1_fk", type:"VARCHAR(36)")
+      column(name: "pr_corresponding_institution_level_2", type:"VARCHAR(255)")
+  }
+}
+
+  changeSet(author: "Jack-Golding (manual)", id:"2022-09-27-1139-002") {
+     addForeignKeyConstraint(
+      baseColumnNames: "pr_corresponding_institution_level_1_fk",
+      baseTableName: "publication_request",
+      constraintName: "publication_request_corresponding_institution_level_1_fk",
+      deferrable: "false",
+      initiallyDeferred: "false",
+      referencedColumnNames: "rdv_id",
+      referencedTableName: "refdata_value"
+    )
+  }
+
+  changeSet(author: "Jack-Golding (manual)", id:"2022-09-27-1141-003") {
+    addColumn (tableName: "party") {
+      column(name: "p_institution_level_1_fk", type:"VARCHAR(36)")
+      column(name: "p_institution_level_2", type:"VARCHAR(255)")
+    }
+  }
+
+  changeSet(author: "Jack-Golding (manual)", id:"2022-09-27-1142-004") {
+     addForeignKeyConstraint(
+      baseColumnNames: "p_institution_level_1_fk",
+      baseTableName: "party",
+      constraintName: "party_institution_level_1_fk",
+      deferrable: "false",
+      initiallyDeferred: "false",
+      referencedColumnNames: "rdv_id",
+      referencedTableName: "refdata_value"
+    )
+  }
+
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1405-005"){
+    grailsChange{
+      change{
+        sql.rows("SELECT p_faculty_fk, p_department FROM ${database.defaultSchemaName}.party".toString()).each {
+          println("LOGDEBUG ${IT}")
+          // sql.execute("INSERT INTO ${database.defaultSchemaName}.party(p_institution_level_1, p_institution_level_2)".toString())
+        }
+      }
+    }
+  }
+
 }

--- a/service/grails-app/migrations/create-mod-oa.groovy
+++ b/service/grails-app/migrations/create-mod-oa.groovy
@@ -1189,36 +1189,37 @@ databaseChangeLog = {
     )
   }
 
-  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1405-028"){
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-28-1333-001"){
     grailsChange{
       change{
-        sql.rows("SELECT p_faculty_fk, p_department FROM ${database.defaultSchemaName}.party".toString()).each {
-          // sql.execute("INSERT INTO ${database.defaultSchemaName}.party(p_institution_level_1_fk, p_institution_level_2)".toString())
-          println("LOGDEBUG : ${it}")        
+        sql.rows("SELECT p_id, p_faculty_fk, p_department FROM ${database.defaultSchemaName}.party".toString()).each {
+          sql.execute("UPDATE ${database.defaultSchemaName}.party SET p_institution_level_1_fk = :instL1, p_institution_level_2 = :instL2 WHERE p_id = :pId".toString(),
+           [pId: it.p_id, instL1: it.p_faculty_fk, instL2: it.p_department])
+        }
       }
     }
   }
-  }
 
-  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1522-005"){
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1333-02"){
     grailsChange{
       change{
-        sql.rows("SELECT p_institution_level_1_fk, p_institution_level_2 FROM ${database.defaultSchemaName}.party".toString()).each {
-          // sql.execute("INSERT INTO ${database.defaultSchemaName}.party(p_institution_level_1_fk, p_institution_level_2)".toString())
-          println("LOGDEBUG : ${it}")        
+        sql.rows("SELECT pr_id, pr_corresponding_faculty_fk, pr_corresponding_department FROM ${database.defaultSchemaName}.publication_request".toString()).each {
+          sql.execute("UPDATE ${database.defaultSchemaName}.publication_request SET pr_corresponding_institution_level_1_fk = :corrInstL1, pr_corresponding_institution_level_2 = :corrInstL2 WHERE pr_id = :prId".toString(), 
+           [prId: it.pr_id, corrInstL1: it.pr_corresponding_faculty_fk, corrInstL2: it.pr_corresponding_department])
+        }
       }
     }
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1344-003") {
+    dropForeignKeyConstraint(baseTableName: "party", constraintName: "party_faculty_fk")
+    dropColumn(columnName: "p_faculty_fk", tableName: "party")
+    dropColumn(columnName: "p_department", tableName: "party")
   }
 
-//    changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1525-031"){
-//     grailsChange{
-//       change{
-//               sql.rows("SELECT p_id, p_faculty_fk, p_department FROM ${database.defaultSchemaName}.party".toString()).each {
-//                 sql.execute("UPDATE ${database.defaultSchemaName}.party SET p_institution_level_1_fk = :instL1, p_institution_level_2 = :instL2 WHERE p_id = :pId".toString(), [pId: it.p_id, instL1: it.p_faculty_fk, instL2: it.p_department])
-//              }
-//             }
-//            }
-
-// }
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1344-004") {
+    dropForeignKeyConstraint(baseTableName: "publication_request", constraintName: "publication_request_corresponding_faculty_fk")
+    dropColumn(columnName: "pr_corresponding_faculty_fk", tableName: "publication_request")
+    dropColumn(columnName: "pr_corresponding_department", tableName: "publication_request")
+  }
 }

--- a/service/grails-app/migrations/create-mod-oa.groovy
+++ b/service/grails-app/migrations/create-mod-oa.groovy
@@ -1189,15 +1189,36 @@ databaseChangeLog = {
     )
   }
 
-  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1405-005"){
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1405-028"){
     grailsChange{
       change{
         sql.rows("SELECT p_faculty_fk, p_department FROM ${database.defaultSchemaName}.party".toString()).each {
-          println("LOGDEBUG ${IT}")
-          // sql.execute("INSERT INTO ${database.defaultSchemaName}.party(p_institution_level_1, p_institution_level_2)".toString())
-        }
+          // sql.execute("INSERT INTO ${database.defaultSchemaName}.party(p_institution_level_1_fk, p_institution_level_2)".toString())
+          println("LOGDEBUG : ${it}")        
       }
     }
   }
+  }
 
+  changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1522-005"){
+    grailsChange{
+      change{
+        sql.rows("SELECT p_institution_level_1_fk, p_institution_level_2 FROM ${database.defaultSchemaName}.party".toString()).each {
+          // sql.execute("INSERT INTO ${database.defaultSchemaName}.party(p_institution_level_1_fk, p_institution_level_2)".toString())
+          println("LOGDEBUG : ${it}")        
+      }
+    }
+  }
+  }
+
+//    changeSet(author: "Jack-Golding (manual)", id: "2022-09-27-1525-031"){
+//     grailsChange{
+//       change{
+//               sql.rows("SELECT p_id, p_faculty_fk, p_department FROM ${database.defaultSchemaName}.party".toString()).each {
+//                 sql.execute("UPDATE ${database.defaultSchemaName}.party SET p_institution_level_1_fk = :instL1, p_institution_level_2 = :instL2 WHERE p_id = :pId".toString(), [pId: it.p_id, instL1: it.p_faculty_fk, instL2: it.p_department])
+//              }
+//             }
+//            }
+
+// }
 }

--- a/service/grails-app/views/party/_party.gson
+++ b/service/grails-app/views/party/_party.gson
@@ -3,4 +3,4 @@ import groovy.transform.Field
 
 @Field 
 Party party
-json g.render(party, ['expand': ['alternateEmails', 'streetAddress', 'faculty']])
+json g.render(party, ['expand': ['alternateEmails', 'streetAddress', 'institutionLevel1']])

--- a/service/grails-app/views/publicationRequest/_publicationRequest.gson
+++ b/service/grails-app/views/publicationRequest/_publicationRequest.gson
@@ -23,7 +23,7 @@ def should_expand = [
   'workIndexedInDOAJ',
   'workOAStatus',
   'checklist',
-  'correspondingFaculty'
+  'correspondingInstitutionLevel1'
 ]
 
 @Field 


### PR DESCRIPTION
Changed publication request and party models, faculty/department is now insitutionLevel1/2, correspondingFaculty/Department is now correspondingInstitutionLevel1/2

Added SQL to migrate all data from faculty/department and corresponding faculty/department to institutionLevel1/2 and correspondingInstitutionLevel1/2 respectively and dropped deprecated columns and foreign keys

[MODOA-31](https://issues.folio.org/browse/MODOA-31)