### PR TITLE
feat:Multiple/Null query parameters

### DIFF
--- a/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
+++ b/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
@@ -22,8 +22,8 @@ class ReportsController {
   private static final String REPORT_QRY = '''select c
 from Charge as c
 where c.paymentPeriod like :pp
-and c.category.value like :cc
-and c.chargeStatus.value like :cs
+and c.category.value in :ccList
+and c.chargeStatus.value in :csList
 '''
 
   GrailsApplication grailsApplication
@@ -51,7 +51,7 @@ and c.chargeStatus.value like :cs
       List<String> header = [ 'instituion', 'period', 'euro', 'doi', 'is_hybrid', 'publisher', 'journal_full_title', 'issn', 'url' ]
       csvWriter.writeNext(header as String[])
 
-      List<Charge> output = Charge.executeQuery(REPORT_QRY, [ pp: paymentPeriod+'%', cc : chargeCategory+'%', cs: chargeStatus+'%' ] )
+      List<Charge> output = Charge.executeQuery(REPORT_QRY, [ pp: paymentPeriod+'%', ccList : chargeCategory.split(','), csList: chargeStatus.split(',') ] )
       
       output.each { chg ->
 

--- a/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
+++ b/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
@@ -21,9 +21,9 @@ class ReportsController {
 
   private static final String REPORT_QRY = '''select c
 from Charge as c
-where c.paymentPeriod like :pp
-and c.category.value in :ccList
-and c.chargeStatus.value in :csList
+where (:pp is null or c.paymentPeriod = :pp)
+and (:ccList is null or c.category.value in :ccList)
+and (:csList is null or c.chargeStatus.value in :csList)
 '''
 
   GrailsApplication grailsApplication
@@ -51,7 +51,7 @@ and c.chargeStatus.value in :csList
       List<String> header = [ 'instituion', 'period', 'euro', 'doi', 'is_hybrid', 'publisher', 'journal_full_title', 'issn', 'url' ]
       csvWriter.writeNext(header as String[])
 
-      List<Charge> output = Charge.executeQuery(REPORT_QRY, [ pp: paymentPeriod+'%', ccList : chargeCategory.split(','), csList: chargeStatus.split(',') ] )
+      List<Charge> output = Charge.executeQuery(REPORT_QRY, [ pp: paymentPeriod, ccList : chargeCategory?.split(','), csList: chargeStatus?.split(',') ] )
       
       output.each { chg ->
 


### PR DESCRIPTION
Added support so that multiple charge categories/statuses can be added to the query parameters, additionally added conditionals so that if no payment period, charge categories or statuses are supplied, query will match with all charges on the respective field

[MODOA-28](https://issues.folio.org/browse/MODOA-28)