### PR TITLE
fix: Duplicate Identifiers

### DIFF
--- a/service/grails-app/migrations/create-mod-oa.groovy
+++ b/service/grails-app/migrations/create-mod-oa.groovy
@@ -1222,4 +1222,9 @@ databaseChangeLog = {
     dropColumn(columnName: "pr_corresponding_faculty_fk", tableName: "publication_request")
     dropColumn(columnName: "pr_corresponding_department", tableName: "publication_request")
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "2022-10-27") {
+    addUniqueConstraint(columnNames: "id_value,id_ns_fk", constraintName: "identifier_ns_value_unique", tableName: "identifier")
+  }
+
 }

--- a/service/grails-app/services/org/olf/oa/BibReferenceService.groovy
+++ b/service/grails-app/services/org/olf/oa/BibReferenceService.groovy
@@ -141,15 +141,18 @@ public class BibReferenceService {
   }
 
   private Identifier identifierLookup(String p_ns, String p_value) {
-    Identifier result = Identifier.createCriteria().get {
+    List<Identifier> result = Identifier.createCriteria().list {
                'ns' {
                  eq('value',p_ns)
                }
                eq('value',p_value)
            }
-    return result;
+    if (result?.size() > 1) {
+      log.warn("Matched >1 identifier namespace and value combination: ${result.size()}");
+      throw new RuntimeException("Namespace and value combination ${p_ns}, ${p_value} matched multiple (${result.size()}) identifiers");
+    }
+    return result[0];
   }
-
   /*
    * Given a list of ns:"namespace, id:"value" pairs, find all known instances that have an identifier in that list.
    * If we don't find any then we don't know about the title.


### PR DESCRIPTION
Added unique key constraint to ensure that namespace, value combinations are unique, additionally added checks within identifierLookup to ensure that an error is thrown when more than one matching identifier namespace, value combination is returned

[MODOA-35](https://issues.folio.org/browse/MODOA-35)