### PR TITLE
fix: Report query and ISSN

### DIFF
--- a/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
+++ b/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
@@ -22,8 +22,8 @@ class ReportsController {
   private static final String REPORT_QRY = '''select c
 from Charge as c
 where (:pp is null or c.paymentPeriod = :pp)
-and (:ccList is null or c.category.value in :ccList)
-and (:csList is null or c.chargeStatus.value in :csList)
+and ((:ccList) is null or c.category.value in (:ccList))
+and ((:csList) is null or c.chargeStatus.value in (:csList))
 '''
 
   GrailsApplication grailsApplication

--- a/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
+++ b/service/grails-app/controllers/org/olf/oa/ReportsController.groovy
@@ -11,6 +11,9 @@ import com.k_int.okapi.OkapiTenantAwareController
 import com.opencsv.CSVWriterBuilder
 import com.opencsv.ICSVWriter
 import org.olf.oa.finance.MonetaryValue
+import org.olf.oa.kb.IdentifierOccurrence
+import org.olf.oa.kb.TitleInstance
+
 
 /**
  * External for OA network connectivity
@@ -56,7 +59,10 @@ and ((:csList) is null or c.chargeStatus.value in (:csList))
       output.each { chg ->
 
         MonetaryValue mv = chg.getEstimatedPrice()
-        PublicationIdentifier pi = chg.owner.identifiers.find { it.type.value == 'issn' }
+
+        List<TitleInstance> ti = chg.owner?.work?.instances?.sort { it?.subType?.value }
+        
+        IdentifierOccurrence io = ti[0].identifiers.find { it.identifier.ns.value == "issn" }
 
         List<String> datarow = [ institution, 
                                  chg.paymentPeriod, 
@@ -65,7 +71,7 @@ and ((:csList) is null or c.chargeStatus.value in (:csList))
                                  chg.owner.workOAStatus?.value == 'hybrid' ? true : false, 
                                  chg.owner.publisher?.label, 
                                  chg.owner.work?.title, 
-                                 pi?.publicationIdentifier, 
+                                 io?.identifier?.value, 
                                  chg.owner.doi == null ? chg.owner.publicationUrl : null ]
         csvWriter.writeNext(datarow as String[])
       }


### PR DESCRIPTION
Fixed error which was being thrown regarding report query string, fixed by surrounding lists within parenthesis
Fixed the OpenAPC charges report to correctly use the ISSN value from the associated work as opposed to the publication identifier

[MODOA-36](https://issues.folio.org/browse/MODOA-36)
[MODOA-37](https://issues.folio.org/browse/MODOA-37)