### PR TITLE
fix: Editable correspondence status

### DIFF
--- a/service/grails-app/domain/org/olf/oa/Correspondence.groovy
+++ b/service/grails-app/domain/org/olf/oa/Correspondence.groovy
@@ -18,7 +18,7 @@ class Correspondence implements MultiTenant<Correspondence> {
   String content
   String correspondent
 
-  @CategoryId(defaultInternal=true)
+  @CategoryId(defaultInternal=false)
   @Defaults(['Awaiting Reply', 'Response Needed', 'Closed'])
   RefdataValue status
 


### PR DESCRIPTION
Changed default internal on correspondence status from true to false to allow for editing within settings

[MODOA-41](https://issues.folio.org/browse/MODOA-41)