### PR TITLE
build: Optional module dependencies removal

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -261,18 +261,6 @@
       ]
     }
   ],
-  "requires":[
-  ],
-  "optional":[
-    {
-      "id": "organizations",
-      "version": "1.2"
-    },
-    {
-      "id": "finance.exchange-rate",
-      "version": "1.0"
-    }
-  ],
   "permissionSets": [
     {
       "permissionName": "oa.settings.get",


### PR DESCRIPTION
Removed optional dependencies for finance.exchange-rate and organizations as neither are used within the backend module

[MODOA-33](https://issues.folio.org/browse/MODOA-33)