### PR TITLE
fix: Main email data type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 1.1.0 In progress
+ * Modified p_main_email datatype from VARCHAR(36) to VARCHAR(255). Refs MODOA-44
 
 ## 1.0.0 2023-01-10
  * Added domain model for Publication requests and partys

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -2,7 +2,8 @@ databaseChangeLog = {
   include file: 'initial-customisations.groovy'
   include file: 'create-mod-oa.groovy'
   include file: 'create-workflow.groovy'
-  include file: 'setup-oa-workflow.groovy'  
+  include file: 'setup-oa-workflow.groovy'
+  include file: 'update-mod-oa-1-1.groovy'  
   
   // Toolkit features opted into.
   include file: 'wtk/hidden-appsetting.feat.groovy'

--- a/service/grails-app/migrations/update-mod-oa-1-1.groovy
+++ b/service/grails-app/migrations/update-mod-oa-1-1.groovy
@@ -1,0 +1,10 @@
+databaseChangeLog = {
+  changeSet(author: "Jack-Golding (manual)", id: "2023-01-31-1520-001") {
+    modifyDataType( 
+      tableName: "party",
+      columnName: "p_main_email",
+      newDataType: "VARCHAR(255)",
+      confirm: "Successfully updated the p_main_email column."
+    )
+  }
+}


### PR DESCRIPTION
Changed p_main_email datatype from VARCHAR(36) to VARCHAR(255)

[MODOA-44](https://issues.folio.org/browse/MODOA-44)