### PR TITLE
fix: Checklist item name regex

### DIFF
--- a/service/grails-app/domain/org/olf/oa/workflow/ChecklistItemDefinition.groovy
+++ b/service/grails-app/domain/org/olf/oa/workflow/ChecklistItemDefinition.groovy
@@ -24,7 +24,7 @@ class ChecklistItemDefinition implements MultiTenant<ChecklistItemDefinition> {
 
   public static String normValue ( String string ) {
     // Remove all diacritics and substitute for compatibility
-    normalizer.normalize( string.trim() ).replaceAll(/\p{M}/, '').replaceAll(/\s+/, '_').toLowerCase()
+    normalizer.normalize( string.trim() ).replaceAll(/\p{M}/, '').replaceAll(/[^a-zA-Z0-9\-_]/, '_').toLowerCase()
   }
   
   private static String tidyLabel ( String string ) {

--- a/service/grails-app/domain/org/olf/oa/workflow/ChecklistItemDefinition.groovy
+++ b/service/grails-app/domain/org/olf/oa/workflow/ChecklistItemDefinition.groovy
@@ -24,7 +24,7 @@ class ChecklistItemDefinition implements MultiTenant<ChecklistItemDefinition> {
 
   public static String normValue ( String string ) {
     // Remove all diacritics and substitute for compatibility
-    normalizer.normalize( string.trim() ).replaceAll(/\p{M}/, '').replaceAll(/[^a-zA-Z0-9\-_]/, '_').toLowerCase()
+    normalizer.normalize( string.trim() ).replaceAll(/\p{M}/, '').replaceAll(/[^\p{L}\p{N}\-_]/, '_').toLowerCase()
   }
   
   private static String tidyLabel ( String string ) {


### PR DESCRIPTION
Fixed function for handling creation of checklist item name from provided label, now all accented letters are replaced with a lowercase version without the accent and all special characters are replaced with an underscore

[UIOA-211](https://issues.folio.org/browse/UIOA-211)