### PR TITLE
fix: Publication title datatype

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 1.1.0 In progress
  * Modified p_main_email datatype from VARCHAR(36) to VARCHAR(255). Refs MODOA-44
  * Fixed Checklist item definition name regex to handle special characters and language specific characters. Refs UIOA-211
+ * Modified pr_title datatype from VARCHAR(255) to VARCHAR(4096) to accommodate longer publication titles. Refs MODOA-46 
 
 ## 1.0.0 2023-01-10
  * Added domain model for Publication requests and partys

--- a/service/grails-app/migrations/update-mod-oa-1-1.groovy
+++ b/service/grails-app/migrations/update-mod-oa-1-1.groovy
@@ -7,4 +7,13 @@ databaseChangeLog = {
       confirm: "Successfully updated the p_main_email column."
     )
   }
+
+  changeSet(author: "Jack-Golding (manual)", id: "2023-02-21-1618-001") {
+    modifyDataType( 
+      tableName: "publication_request",
+      columnName: "pr_title",
+      newDataType: "VARCHAR(4096)",
+      confirm: "Successfully updated the pr_title column."
+    )
+  }
 }


### PR DESCRIPTION
Modified pr_title datatype from VARCHAR(255) to VARCHAR(4096) to accommodate longer publication titles

[MODOA-46](https://issues.folio.org/browse/MODOA-46)