### PR TITLE
build: Hibernate-core dependency bump

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -162,7 +162,7 @@ dependencies {
 
 
   compile "org.springframework.boot:spring-boot-starter-undertow" // Replaces spring-boot-starter-tomcat
-  compile "org.hibernate:hibernate-core:5.4.19.Final"             // Update to latest 5.4
+  compile "org.hibernate:hibernate-core:5.4.33.Final"             // Update to latest 5.4
   compile "org.hibernate:hibernate-java8:5.4.19.Final"
   runtime "com.zaxxer:HikariCP:3.4.5"                             // Replaces Tomcat JDBC pool
   runtime "org.postgresql:postgresql:42.5.3"


### PR DESCRIPTION
Bumped hibernate-core dependency to version 5.4.33

[MODOA-47](https://issues.folio.org/browse/MODOA-47)