### PR TITLE
chore: Release 1.1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
-## 1.1.0 In progress
+## 1.1.0 2023-03-20
  * Modified p_main_email datatype from VARCHAR(36) to VARCHAR(255). Refs MODOA-44
- * Fixed Checklist item definition name regex to handle special characters and language specific characters. Refs UIOA-211
  * Modified pr_title datatype from VARCHAR(255) to VARCHAR(4096) to accommodate longer publication titles. Refs MODOA-46
+ * Fixed Checklist item definition name regex to handle special characters and language specific characters. Refs UIOA-211
  * Bumped dependencies for postgresql, opencsv, kafka-clients, commons-io. Refs MODOA-47
 
 ## 1.0.0 2023-01-10

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -13,7 +13,7 @@ gradleWrapperVersion=5.4
 
 # Application
 appName=mod-oa
-appVersion=1.1.0-SNAPSHOT
+appVersion=1.1.0
 dockerTagSuffix=
 dockerRepo=folioci
 


### PR DESCRIPTION
NEWS.md update and removed SNAPSHOT from version

MODOA-49