### PR TITLE
build: Bumped commons-io version

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -131,7 +131,7 @@ dependencies {
 
 
 	implementation 'com.opencsv:opencsv:5.7.1'
-	implementation 'commons-io:commons-io:2.6'
+	implementation 'commons-io:commons-io:2.7'
 	implementation 'io.github.virtualdogbert:logback-groovy-config:1.14.1' // Grails 5 and up no longer supports groovy files for logback config
 	compileOnly 'ch.qos.logback:logback-classic:1.4.7'
 


### PR DESCRIPTION
Bumped commons-io from 2.6 to 2.7

[MODOA-54](https://issues.folio.org/browse/MODOA-54)