### PR TITLE
build: Bumped spring-webmvc version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2.0.0 In progress
  * Upgraded to Grails 5
  * MODOA-51 Added primary keys to database Schema
+ * Bumped dependencies for commons-io and spring-webmvc. Refs MODOA-54/55
 
 ## 1.1.0 2023-03-20
  * Modified p_main_email datatype from VARCHAR(36) to VARCHAR(255). Refs MODOA-44

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -159,6 +159,9 @@ dependencies {
 	testImplementation( 'com.athaydes:spock-reports:2.3.2-groovy-3.0' ) {
 		transitive = false // this avoids affecting your version of Groovy/Spock
 	}
+
+	// Bumping this manually to avoid potential security issue with spring-webmvc-5.3.25
+	implementation 'org.springframework:spring-webmvc:5.3.28'
 }
 
 bootRun {


### PR DESCRIPTION
Bumped spring-webmvc version from 5.3.19 to 5.3.28

[MODOA-55](https://issues.folio.org/browse/MODOA-55)