### PR TITLE
MODOA-63: Added in missing charge perms

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -614,6 +614,31 @@
       ]
     },
     {
+      "permissionName": "oa.charges.collection.get",
+      "displayName": "Charges collection get",
+      "description": "Get a collection of charge records"
+    },
+    {
+      "permissionName": "oa.charges.item.get",
+      "displayName": "Charges get",
+      "description": "Get a charge record"
+    },
+    {
+      "permissionName": "oa.charges.item.post",
+      "displayName": "Charges post",
+      "description": "Post a charge record"
+    },
+    {
+      "permissionName": "oa.charges.item.put",
+      "displayName": "Charges put",
+      "description": "Put a charge record"
+    },
+    {
+      "permissionName": "oa.charges.item.delete",
+      "displayName": "Charges delete",
+      "description": "Delete a charge record"
+    },
+    {
       "permissionName": "oa.charges.view",
       "subPermissions": [
         "oa.charges.collection.get",


### PR DESCRIPTION
A set of permissions used on endpoints were not defined. This PR adds definitions for the (granular) perms:

- oa.charges.collection.get
- oa.charges.item.get
- oa.charges.item.post
- oa.charges.item.put
- oa.charges.item.delete