### PR TITLE
MODOA-69: Missing interface dependencies in module descriptor in mod-oa

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -467,6 +467,12 @@
       ]
     }
   ],
+  "optional": [
+    {
+      "id": "erm",
+      "version": "7.0"
+    }
+  ],
   "permissionSets": [
     {
       "permissionName": "oa.settings.get",


### PR DESCRIPTION
build: Add optional okapi dependencies to ModuleDescriptor

MODOA-69