### PR TITLE
chore: Release 3.1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-## 3.1.0 - In progress
+## 3.1.0 2024-12-04
+  * MODOA-69 Missing interface dependencies in module descriptor in mod-oa
+  * MODOA-66 Update module license, guidance and dependencies for mod-oa
 
 ## 3.0.1 2024-11-06
   * Fixed borked release

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -18,7 +18,7 @@ gradleWrapperVersion=5.4
 
 # Application
 appName=mod-oa
-appVersion=3.1.0-SNAPSHOT
+appVersion=3.1.0
 okapiInterfaceVersion=2.1
 dockerTagSuffix=
 dockerRepo=folioci

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -19,6 +19,6 @@ gradleWrapperVersion=5.4
 # Application
 appName=mod-oa
 appVersion=3.1.0
-okapiInterfaceVersion=2.1
+okapiInterfaceVersion=2.2
 dockerTagSuffix=
 dockerRepo=folioci


### PR DESCRIPTION
Added NEWS section and changed version to 3.1.0

MODOA-64

DO NOT MERGE - until mod-oa release 3.1.0